### PR TITLE
fix: joystick detection

### DIFF
--- a/src/js2xbox/events.cpp
+++ b/src/js2xbox/events.cpp
@@ -66,10 +66,14 @@ int events::is_event_device(const struct dirent *dir) {
 
 const char* find_existing_evdev() {
 	glob_t globbuf;
+	char *result = NULL;
 
 	int rc = glob(EVDEV_WILDCARD, 0, NULL, &globbuf);
 	if (rc == 0) {
-		return *globbuf.gl_pathv;
+		result = strdup(globbuf.gl_pathv[0]);
+		globfree(&globbuf);
+
+		return result;
 	}
 
 	// If glob fails, check for fallback device

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1581,12 +1581,12 @@ void initConfig()
         {
             const std::string &ssFolderValue = conf_map.at("retrorun_extra_retrogame_name");
             events::extra_retrogame_name= ssFolderValue;
-            logger.log(Logger::DEB, "retrorun_extra_retrogame_name set to:%s", events::extra_retrogame_name);
+            logger.log(Logger::DEB, "retrorun_extra_retrogame_name set to:%s", events::extra_retrogame_name.c_str());
         }
         catch (...)
         {
             logger.log(Logger::DEB, "retrorun_extra_retrogame_name parameter not found in retrorun.cfg using default values.");
-            
+
         }
 
         try
@@ -1606,12 +1606,12 @@ void initConfig()
         {
             const std::string &ssFolderValue = conf_map.at("retrorun_extra_evdev_name");
             events::extra_osh_name= ssFolderValue;
-            logger.log(Logger::DEB, "retrorun_extra_evdev_name set to:%s", events::extra_evdev_name);
+            logger.log(Logger::DEB, "retrorun_extra_evdev_name set to:%s", events::extra_evdev_name.c_str());
         }
         catch (...)
         {
             logger.log(Logger::DEB, "retrorun_extra_evdev_name parameter not found in retrorun.cfg using default values.");
-            
+
         }
 
         try


### PR DESCRIPTION
Improve joystick device detection on clone hardware by matching against wildcard paths in /dev/input/by-path using glob(). This allows compatibility with more variants (e.g. R36 Max clones) that don’t follow the exact hardcoded device names.

Also adds fallback handling for generic event paths and respects extra_evdev_name when provided.

Joystick detection logic adapted from the ROCKNIX project. Thanks to @stolen and @navy1978 for the inspiration and groundwork.